### PR TITLE
Update ownership to hyperdevs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 ### Github issue (delete if this does not apply)
-https://github.com/bq/mini-kotlin/issues/change_me_issue_number
+https://github.com/hyperdevs-team/mini-kotlin/issues/change_me_issue_number
 
 ### PR's key points
  

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.iml
 .gradle
-.idea/
 /local.properties
 /.idea/workspace.xml
 /.idea/libraries
@@ -19,6 +18,13 @@
 # User-specific stuff:
 .idea/**/workspace.xml
 .idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+.idea/**/libraries-with-intellij-classes.xml
 
 # Sensitive or high-churn files:
 .idea/**/dataSources/
@@ -28,6 +34,7 @@
 .idea/**/sqlDataSources.xml
 .idea/**/dynamic.xml
 .idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
 
 # Gradle:
 .idea/**/gradle.xml
@@ -43,6 +50,30 @@
 
 # IntelliJ
 /out/
+*.iml
+.idea/encodings.xml
+.idea/vcs.xml
+.idea/codeStyles/Project.xml
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/libraries
+.idea/dictionaries
+.idea/runConfigurations.xml
+.idea/terminal.xml
+.idea/inspectionProfiles/
+.idea/jarRepositories.xml
+.idea/modules
+.idea/markdown-exported-files.xml
+.idea/markdown-navigator.xml
+.idea/markdown-navigator-enh.xml
+.idea/markdown-navigator/
+.idea/misc.xml
+.idea/modules.xml
+.idea/caches
+.idea/compiler.xml
+.idea/assetWizardSettings.xml
+.idea/navEditor.xml
+.idea/.name
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/
@@ -50,11 +81,20 @@
 # JIRA plugin
 atlassian-ide-plugin.xml
 
+# Cursive Clojure plugin
+.idea/replstate.xml
+
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
 
 ### Intellij Patch ###
 # Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721

--- a/.idea/copyright/Apache_2_0.xml
+++ b/.idea/copyright/Apache_2_0.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="Copyright &amp;#36;today.year HyperDevs&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;   http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
+    <option name="myName" value="Apache 2.0" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+  <settings default="Apache 2.0">
+    <module2copyright>
+      <element module="Project Files" copyright="Apache 2.0" />
+    </module2copyright>
+  </settings>
+</component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - No security issues fixed!
 
+## [2.0.0] - 2021-05-01
+### Changed
+- Changed repo ownership to [hyperdevs-team](https://github.com/hyperdevs-team). Thanks [bq](https://github.com/bq) for all the work!
+- Changed package names from `com.bq.*` to `com.hyperdevs.*`
+
 ## [1.4.0] - 2020-12-15
 ### Added
 - Upgrade Kotlin to 1.4.21 and Kodein to 7.1.0, apart from other Android dependencies.
@@ -109,23 +114,24 @@ state (`success` or `failure`)
 ### Added
 - Initial architecture release.
 
-[Unreleased]: https://github.com/bq/mini-kotlin/compare/1.4.0...HEAD
-[1.4.0]: https://github.com/bq/mini-kotlin/compare/1.3.3...1.4.0
-[1.3.3]: https://github.com/bq/mini-kotlin/compare/1.3.2...1.3.3
-[1.3.2]: https://github.com/bq/mini-kotlin/compare/1.3.1...1.3.2
-[1.3.1]: https://github.com/bq/mini-kotlin/compare/1.3.0...1.3.1
-[1.3.0]: https://github.com/bq/mini-kotlin/compare/1.2.0...1.3.0
-[1.2.0]: https://github.com/bq/mini-kotlin/compare/1.1.2...1.2.0
-[1.1.2]: https://github.com/bq/mini-kotlin/compare/1.1.1...1.1.2
-[1.1.1]: https://github.com/bq/mini-kotlin/compare/1.1.0...1.1.1
-[1.1.0]: https://github.com/bq/mini-kotlin/compare/1.0.9...1.1.0
-[1.0.9]: https://github.com/bq/mini-kotlin/compare/1.0.8...1.0.9
-[1.0.8]: https://github.com/bq/mini-kotlin/compare/1.0.7...1.0.8
-[1.0.7]: https://github.com/bq/mini-kotlin/compare/1.0.6...1.0.7
-[1.0.6]: https://github.com/bq/mini-kotlin/compare/1.0.5...1.0.6
-[1.0.5]: https://github.com/bq/mini-kotlin/compare/1.0.4...1.0.5
-[1.0.4]: https://github.com/bq/mini-kotlin/compare/1.0.3...1.0.4
-[1.0.3]: https://github.com/bq/mini-kotlin/compare/1.0.2...1.0.3
-[1.0.2]: https://github.com/bq/mini-kotlin/compare/1.0.1...1.0.2
-[1.0.1]: https://github.com/bq/mini-kotlin/compare/1.0.0...1.0.1
-[1.0.0]: https://github.com/bq/mini-kotlin/releases/tag/1.0.0
+[Unreleased]: https://github.com/hyperdevs-team/mini-kotlin/compare/2.0.0...HEAD
+[2.0.0]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.4.0...2.0.0
+[1.4.0]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.3.3...1.4.0
+[1.3.3]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.3.2...1.3.3
+[1.3.2]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.3.1...1.3.2
+[1.3.1]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.3.0...1.3.1
+[1.3.0]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.2.0...1.3.0
+[1.2.0]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.1.2...1.2.0
+[1.1.2]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.1.1...1.1.2
+[1.1.1]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.1.0...1.1.1
+[1.1.0]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.0.9...1.1.0
+[1.0.9]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.0.8...1.0.9
+[1.0.8]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.0.7...1.0.8
+[1.0.7]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.0.6...1.0.7
+[1.0.6]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.0.5...1.0.6
+[1.0.5]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.0.4...1.0.5
+[1.0.4]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.0.3...1.0.4
+[1.0.3]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.0.2...1.0.3
+[1.0.2]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.0.1...1.0.2
+[1.0.1]: https://github.com/hyperdevs-team/mini-kotlin/compare/1.0.0...1.0.1
+[1.0.0]: https://github.com/hyperdevs-team/mini-kotlin/releases/tag/1.0.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Mini
-[![Release](https://jitpack.io/v/bq/mini-kotlin.svg)](https://jitpack.io/#bq/mini-kotlin)
+[![Release](https://jitpack.io/v/hyperdevs-team/mini-kotlin.svg)](https://jitpack.io/#hyperdevs-team/mini-kotlin)
 
 Mini is a minimal Flux architecture written in Kotlin that also adds a mix of useful features to build UIs fast.
 
@@ -184,21 +184,21 @@ Add the following dependencies to your app's `build.gradle`:
 
 ```groovy
 dependencies {
-    def mini_version = "1.4.0"
+    def mini_version = "2.0.0"
     // Minimum working dependencies
-    implementation "com.github.bq.mini-kotlin:mini-android:$mini_version"
-    kapt "com.github.bq.mini-kotlin:mini-processor:$mini_version"
+    implementation "com.github.hyperdevs-team.mini-kotlin:mini-android:$mini_version"
+    kapt "com.github.hyperdevs-team.mini-kotlin:mini-processor:$mini_version"
 
     // RxJava 2 helper libraries
-    implementation "com.github.bq.mini-kotlin:mini-rx2:$mini_version"
-    implementation "com.github.bq.mini-kotlin:mini-rx2-android:$mini_version"
+    implementation "com.github.hyperdevs-team.mini-kotlin:mini-rx2:$mini_version"
+    implementation "com.github.hyperdevs-team.mini-kotlin:mini-rx2-android:$mini_version"
 
     // Kodein helper libraries
-    implementation "com.github.bq.mini-kotlin:mini-kodein:$mini_version"
-    implementation "com.github.bq.mini-kotlin:mini-kodein-android:$mini_version"
+    implementation "com.github.hyperdevs-team.mini-kotlin:mini-kodein:$mini_version"
+    implementation "com.github.hyperdevs-team.mini-kotlin:mini-kodein-android:$mini_version"
 
     // Testing helper libraries
-    androidTestImplementation "com.github.bq.mini-kotlin:mini-testing:$mini_version"
+    androidTestImplementation "com.github.hyperdevs-team.mini-kotlin:mini-testing:$mini_version"
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,13 +8,31 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //Android
 android {
     compileSdkVersion android_target_sdk
     buildToolsVersion android_build_tools_version
 
     defaultConfig {
-        applicationId "com.bq.mini"
+        applicationId "com.hyperdevs.mini"
         minSdkVersion 21
         targetSdkVersion android_target_sdk
         versionCode android_version_code

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,3 +1,21 @@
+<!--
+  ~ Copyright 2021 HyperDevs
+  ~
+  ~ Copyright 2020 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="org.sample">

--- a/app/src/main/java/org/sample/SampleActivity.kt
+++ b/app/src/main/java/org/sample/SampleActivity.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.sample
 
 import android.os.Bundle

--- a/app/src/main/java/org/sample/SampleData.kt
+++ b/app/src/main/java/org/sample/SampleData.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.sample
 
 import mini.Action

--- a/app/src/main/java/org/sample/SampleRxActivity.kt
+++ b/app/src/main/java/org/sample/SampleRxActivity.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.sample
 
 import android.os.Bundle

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2021 HyperDevs
+  ~
+  ~ Copyright 2020 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"
     android:height="108dp"

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,3 +1,21 @@
+<!--
+  ~ Copyright 2021 HyperDevs
+  ~
+  ~ Copyright 2020 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"
     android:height="108dp"

--- a/app/src/main/res/layout/home_activity.xml
+++ b/app/src/main/res/layout/home_activity.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2021 HyperDevs
+  ~
+  ~ Copyright 2020 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/app/src/main/res/layout/login_activity.xml
+++ b/app/src/main/res/layout/login_activity.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!--
+  ~ Copyright 2021 HyperDevs
+  ~
+  ~ Copyright 2020 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/loginLayout"
     android:layout_width="match_parent"

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2021 HyperDevs
+  ~
+  ~ Copyright 2020 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2021 HyperDevs
+  ~
+  ~ Copyright 2020 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2021 HyperDevs
+  ~
+  ~ Copyright 2020 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <resources>
     <color name="colorPrimary">#000000</color>
     <color name="colorPrimaryDark">#121212</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2021 HyperDevs
+  ~
+  ~ Copyright 2020 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <resources>
     <!--Default text sizes-->
     <dimen name="text_size_small">12sp</dimen>

--- a/app/src/main/res/values/ic_launcher_background.xml
+++ b/app/src/main/res/values/ic_launcher_background.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2021 HyperDevs
+  ~
+  ~ Copyright 2020 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <resources>
     <color name="ic_launcher_background">#000000</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,21 @@
+<!--
+  ~ Copyright 2021 HyperDevs
+  ~
+  ~ Copyright 2020 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <resources>
     <string name="app_name">Mini Sample Login</string>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,3 +1,21 @@
+<!--
+  ~ Copyright 2021 HyperDevs
+  ~
+  ~ Copyright 2020 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <resources>
 
     <!-- Base application theme. -->

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 apply plugin: "com.github.ben-manes.versions"
 apply plugin: 'com.gladed.androidgitversion'
 
@@ -46,7 +64,7 @@ allprojects {
     }
 
     version = mini_version
-    group = "com.bq.mini"
+    group = "com.hyperdevs.mini"
 
     repositories {
         jcenter()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,21 @@
+#
+# Copyright 2021 HyperDevs
+#
+# Copyright 2020 BQ
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # Project-wide Gradle settings.
 # IDE (e.g. Android Studio) users:
 # Gradle settings configured through the IDE *will take*

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,21 @@
+#
+# Copyright 2021 HyperDevs
+#
+# Copyright 2020 BQ
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 #Mon Dec 14 20:31:47 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists

--- a/jitpack-android.gradle
+++ b/jitpack-android.gradle
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 task sourcesJar(type: Jar) {
     classifier = 'sources'
     from android.sourceSets.main.java.srcDirs

--- a/jitpack.gradle
+++ b/jitpack.gradle
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 apply plugin: 'java'
 apply plugin: 'maven'
 

--- a/mini-android/build.gradle
+++ b/mini-android/build.gradle
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply plugin: "com.github.dcendents.android-maven"
@@ -28,6 +46,7 @@ dependencies {
 
     api "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     api "androidx.appcompat:appcompat:1.2.0"
+    api "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
     api "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
 
     testImplementation "junit:junit:4.13"

--- a/mini-android/src/main/AndroidManifest.xml
+++ b/mini-android/src/main/AndroidManifest.xml
@@ -1,1 +1,19 @@
+<!--
+  ~ Copyright 2021 HyperDevs
+  ~
+  ~ Copyright 2020 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <manifest package="com.mini" />

--- a/mini-android/src/main/java/com/mini/android/FluxActivity.kt
+++ b/mini-android/src/main/java/com/mini/android/FluxActivity.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mini.android
 
 import androidx.appcompat.app.AppCompatActivity

--- a/mini-android/src/main/java/com/mini/android/FluxFragment.kt
+++ b/mini-android/src/main/java/com/mini/android/FluxFragment.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mini.android
 
 import androidx.fragment.app.Fragment

--- a/mini-android/src/main/java/com/mini/android/FluxViewModel.kt
+++ b/mini-android/src/main/java/com/mini/android/FluxViewModel.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mini.android
 
 import androidx.annotation.CallSuper

--- a/mini-android/src/main/java/com/mini/android/ViewExtensions.kt
+++ b/mini-android/src/main/java/com/mini/android/ViewExtensions.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mini.android
 
 import android.view.View

--- a/mini-android/src/main/java/com/mini/android/ViewUtil.kt
+++ b/mini-android/src/main/java/com/mini/android/ViewUtil.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mini.android
 
 import android.content.res.Resources

--- a/mini-common/build.gradle
+++ b/mini-common/build.gradle
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 apply plugin: 'kotlin'
 apply from: "../jitpack.gradle"
 

--- a/mini-common/src/main/java/mini/AndroidInterop.kt
+++ b/mini-common/src/main/java/mini/AndroidInterop.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini
 
 /**

--- a/mini-common/src/main/java/mini/Annotations.kt
+++ b/mini-common/src/main/java/mini/Annotations.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini
 
 import java.lang.annotation.Inherited

--- a/mini-common/src/main/java/mini/BaseAction.kt
+++ b/mini-common/src/main/java/mini/BaseAction.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini
 
 /**

--- a/mini-common/src/main/java/mini/CloseableTracker.kt
+++ b/mini-common/src/main/java/mini/CloseableTracker.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini
 
 import java.io.Closeable

--- a/mini-common/src/main/java/mini/CompositeCloseable.kt
+++ b/mini-common/src/main/java/mini/CompositeCloseable.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini
 
 import java.io.Closeable

--- a/mini-common/src/main/java/mini/Dispatcher.kt
+++ b/mini-common/src/main/java/mini/Dispatcher.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini
 
 import java.io.Closeable

--- a/mini-common/src/main/java/mini/Interceptor.kt
+++ b/mini-common/src/main/java/mini/Interceptor.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini
 
 typealias Interceptor = (action: Any, chain: Chain) -> Any

--- a/mini-common/src/main/java/mini/LoggerInterceptor.kt
+++ b/mini-common/src/main/java/mini/LoggerInterceptor.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini
 
 import kotlinx.coroutines.GlobalScope

--- a/mini-common/src/main/java/mini/Resource.kt
+++ b/mini-common/src/main/java/mini/Resource.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @file:Suppress("UNCHECKED_CAST")
 
 package mini

--- a/mini-common/src/main/java/mini/Store.kt
+++ b/mini-common/src/main/java/mini/Store.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini
 
 import org.jetbrains.annotations.TestOnly

--- a/mini-common/src/main/java/mini/Threading.kt
+++ b/mini-common/src/main/java/mini/Threading.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini
 
 import android.os.Handler

--- a/mini-common/src/main/java/mini/flow/FlowUtils.kt
+++ b/mini-common/src/main/java/mini/flow/FlowUtils.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.flow
 
 import kotlinx.coroutines.FlowPreview

--- a/mini-common/src/test/kotlin/mini/CompositeCloseableTest.kt
+++ b/mini-common/src/test/kotlin/mini/CompositeCloseableTest.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini
 
 import org.amshove.kluent.`should be equal to`

--- a/mini-common/src/test/kotlin/mini/DispatcherTest.kt
+++ b/mini-common/src/test/kotlin/mini/DispatcherTest.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini
 
 import org.amshove.kluent.`should be equal to`

--- a/mini-common/src/test/kotlin/mini/ResourceTest.kt
+++ b/mini-common/src/test/kotlin/mini/ResourceTest.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini
 
 import org.amshove.kluent.`should be equal to`

--- a/mini-common/src/test/kotlin/mini/SampleStore.kt
+++ b/mini-common/src/test/kotlin/mini/SampleStore.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini
 
 class SampleStore : Store<String>() {

--- a/mini-common/src/test/kotlin/mini/StoreTest.kt
+++ b/mini-common/src/test/kotlin/mini/StoreTest.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini
 
 import org.amshove.kluent.`should be equal to`

--- a/mini-common/src/test/kotlin/mini/TestDispatcher.kt
+++ b/mini-common/src/test/kotlin/mini/TestDispatcher.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini
 
 import kotlin.reflect.KClass

--- a/mini-common/src/test/kotlin/mini/flow/FlowUtilsTest.kt
+++ b/mini-common/src/test/kotlin/mini/flow/FlowUtilsTest.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.flow
 
 import kotlinx.coroutines.CoroutineStart

--- a/mini-kodein-android/build.gradle
+++ b/mini-kodein-android/build.gradle
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: "com.github.dcendents.android-maven"

--- a/mini-kodein-android/src/main/AndroidManifest.xml
+++ b/mini-kodein-android/src/main/AndroidManifest.xml
@@ -1,2 +1,20 @@
+<!--
+  ~ Copyright 2021 HyperDevs
+  ~
+  ~ Copyright 2020 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="mini.kodein.android" />

--- a/mini-kodein-android/src/main/java/mini/kodein/android/KodeinAndroidUtils.kt
+++ b/mini-kodein-android/src/main/java/mini/kodein/android/KodeinAndroidUtils.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.kodein.android
 
 import androidx.annotation.MainThread

--- a/mini-kodein-android/src/main/res/values/strings.xml
+++ b/mini-kodein-android/src/main/res/values/strings.xml
@@ -1,3 +1,21 @@
+<!--
+  ~ Copyright 2021 HyperDevs
+  ~
+  ~ Copyright 2020 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <resources>
     <string name="app_name">mini-kodein-android</string>
 </resources>

--- a/mini-kodein/build.gradle
+++ b/mini-kodein/build.gradle
@@ -2,6 +2,24 @@ apply plugin: 'kotlin'
 apply plugin: 'java-library'
 apply from: "../jitpack.gradle"
 
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Needed because of the Kodein dependency.
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {

--- a/mini-kodein/src/main/java/mini/kodein/KodeinUtils.kt
+++ b/mini-kodein/src/main/java/mini/kodein/KodeinUtils.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.kodein
 
 import mini.Store

--- a/mini-processor/build.gradle
+++ b/mini-processor/build.gradle
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
 apply from: "../jitpack.gradle"

--- a/mini-processor/src/main/java/mini/processor/ActionTypesGenerator.kt
+++ b/mini-processor/src/main/java/mini/processor/ActionTypesGenerator.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.processor
 
 import com.squareup.kotlinpoet.*

--- a/mini-processor/src/main/java/mini/processor/MiniProcessor.kt
+++ b/mini-processor/src/main/java/mini/processor/MiniProcessor.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.processor
 
 import com.squareup.kotlinpoet.FileSpec

--- a/mini-processor/src/main/java/mini/processor/ProcessorUtils.kt
+++ b/mini-processor/src/main/java/mini/processor/ProcessorUtils.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.processor
 
 import com.squareup.kotlinpoet.FileSpec

--- a/mini-processor/src/main/java/mini/processor/ReducersGenerator.kt
+++ b/mini-processor/src/main/java/mini/processor/ReducersGenerator.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.processor
 
 import com.squareup.kotlinpoet.*

--- a/mini-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/mini-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,19 @@
+#
+# Copyright 2021 HyperDevs
+#
+# Copyright 2020 BQ
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 mini.processor.MiniProcessor

--- a/mini-rx2-android/build.gradle
+++ b/mini-rx2-android/build.gradle
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: "com.github.dcendents.android-maven"

--- a/mini-rx2-android/src/androidTest/java/mini/rx/android/ExampleInstrumentedTest.kt
+++ b/mini-rx2-android/src/androidTest/java/mini/rx/android/ExampleInstrumentedTest.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.rx.android
 
 import androidx.test.platform.app.InstrumentationRegistry

--- a/mini-rx2-android/src/main/AndroidManifest.xml
+++ b/mini-rx2-android/src/main/AndroidManifest.xml
@@ -1,2 +1,20 @@
+<!--
+  ~ Copyright 2021 HyperDevs
+  ~
+  ~ Copyright 2020 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="mini.rx.android" />

--- a/mini-rx2-android/src/main/java/mini/rx/android/activities/FluxRxActivity.kt
+++ b/mini-rx2-android/src/main/java/mini/rx/android/activities/FluxRxActivity.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.rx.android.activities
 
 import androidx.annotation.CallSuper

--- a/mini-rx2-android/src/main/java/mini/rx/android/viewmodels/RxAndroidViewModel.kt
+++ b/mini-rx2-android/src/main/java/mini/rx/android/viewmodels/RxAndroidViewModel.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.rx.android.viewmodels
 
 import android.app.Application

--- a/mini-rx2-android/src/main/java/mini/rx/android/viewmodels/RxViewModel.kt
+++ b/mini-rx2-android/src/main/java/mini/rx/android/viewmodels/RxViewModel.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.rx.android.viewmodels
 
 import androidx.annotation.CallSuper

--- a/mini-rx2-android/src/main/res/values/strings.xml
+++ b/mini-rx2-android/src/main/res/values/strings.xml
@@ -1,3 +1,21 @@
+<!--
+  ~ Copyright 2021 HyperDevs
+  ~
+  ~ Copyright 2020 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <resources>
     <string name="app_name">mini-rx-android</string>
 </resources>

--- a/mini-rx2/build.gradle
+++ b/mini-rx2/build.gradle
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 apply plugin: 'kotlin'
 apply plugin: 'java-library'
 apply from: "../jitpack.gradle"

--- a/mini-rx2/src/main/java/mini/rx/RxUtils.kt
+++ b/mini-rx2/src/main/java/mini/rx/RxUtils.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.rx
 
 import io.reactivex.BackpressureStrategy

--- a/mini-rx2/src/main/java/mini/rx/StateMerger.kt
+++ b/mini-rx2/src/main/java/mini/rx/StateMerger.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.rx
 
 import io.reactivex.Flowable

--- a/mini-rx2/src/test/kotlin/mini/rx/RxUtilsKtTest.kt
+++ b/mini-rx2/src/test/kotlin/mini/rx/RxUtilsKtTest.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.rx
 
 import mini.SampleStore

--- a/mini-testing/build.gradle
+++ b/mini-testing/build.gradle
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 apply plugin: 'kotlin'
 apply plugin: 'java-library'
 apply from: "../jitpack.gradle"

--- a/mini-testing/src/main/java/mini/testing/CleanStateRule.kt
+++ b/mini-testing/src/main/java/mini/testing/CleanStateRule.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.testing
 
 import mini.Store

--- a/mini-testing/src/main/java/mini/testing/TestDispatcherInterceptor.kt
+++ b/mini-testing/src/main/java/mini/testing/TestDispatcherInterceptor.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.testing
 
 import mini.BaseAction

--- a/mini-testing/src/main/java/mini/testing/TestDispatcherRule.kt
+++ b/mini-testing/src/main/java/mini/testing/TestDispatcherRule.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package mini.testing
 
 import mini.Dispatcher

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,19 @@
+/*
+ * Copyright 2021 HyperDevs
+ *
+ * Copyright 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 include ':app', ':mini-processor', ':mini-common', ':mini-android', ':mini-rx2', ':mini-rx2-android', ':mini-kodein', ':mini-kodein-android', ':mini-testing'


### PR DESCRIPTION
### PR's key points
Update the ownership to hypedevs. 
The gitignore file have been modified so we can upload the copyright template updated. 

### Definition of Done
- [ ] Tests pass
- [ ] Works with Proguard
- [ ] There is no outcommented or debug code left